### PR TITLE
initial ease of use commit adding step and run methods to model class

### DIFF
--- a/dgl_ptm/dgl_ptm/__init__.py
+++ b/dgl_ptm/dgl_ptm/__init__.py
@@ -1,7 +1,8 @@
 """Documentation about dgl_ptm"""
 import logging
 
-from dgl_ptm.model import initialize_model, step
+#from dgl_ptm.model import initialize_model, step
+from dgl_ptm.model.initialize_model import PovertyTrapModel
 # from dgl_ptm.agent import agent_update
 # from dgl_ptm.agentInteraction import trade_money
 # from dgl_ptm.network import global_attachment, link_deletion

--- a/dgl_ptm/dgl_ptm/model/step.py
+++ b/dgl_ptm/dgl_ptm/model/step.py
@@ -3,12 +3,14 @@
 
 # step - time-stepping for the poverty-trap model
 
-from dgl_ptm.agentInteraction import trade_money
-from dgl_ptm.network import local_attachment, link_deletion, global_attachment
-from dgl_ptm.agent import agent_update
-from dgl_ptm.model import data_collection
+from dgl_ptm.agentInteraction.trade_money import trade_money
+from dgl_ptm.network.local_attachment import local_attachment 
+from dgl_ptm.network.link_deletion import link_deletion 
+from dgl_ptm.network.global_attachment import global_attachment
+from dgl_ptm.agent.agent_update import agent_update
+from dgl_ptm.model.data_collection import data_collection
 
-def step(agent_graph, timestep, params):
+def ptm_step(agent_graph, timestep, params):
     '''
         step - time-stepping module for the poverty-trap model
 


### PR DESCRIPTION
slight restructuring. basic use follows:


`import dgl_ptm as ptm` 
`a = ptm.PovertyTrapModel(model_identifier='test1')`
`a.set_model_parameters(default=True)`
`a.initialize_model()`
`a.run()`

PovertyTrapModel class is available again directly on import. A `step` and run `method` are efiined for the model class. Step imports the sep function from `model/step.py` while run excutes step in a loop.

current failure is on keys in the constituent functions of ptm_step. These need to sttll be cleaned sync'd and consolidated 