### PR TITLE
Install DGL using pip instead of conda.

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -8,6 +8,6 @@ dependencies:
   - pytorch::pytorch==2.0.0
   - pytorch::torchvision==0.15.0
   - pytorch::torchaudio==2.0.0
-  - dglteam::dgl
+#  - dglteam::dgl #use "pip install dgl" instead.
   - xarray
   - zarr


### PR DESCRIPTION
resolves #45 

Very minor hotfix to disable installing DGL using conda and commented to use pip instead.