### PR TITLE
Environment fix - temporary fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 The deep graph library reimplementation of the poverty trap model.
+
+# Installation:
+
+## Create environment from file
+
+mamba env create -f environment.yaml
+
+* This assumes that the user already has mamba installed on the machine. Conda can also be used but at the cost of speed.
+
+## If environment.yaml file does not work, an alternative approach:
+
+### Create empty mamba environment
+
+mamba create -n dgl_ptm
+
+### Install dependencies
+
+mamba install python=3.11 numpy scipy-1.10.1 xarray zarr pyyaml ipykernel pytorch=2.1.1 torchvision=0.16.0 torchaudio=2.1.0 dgl==1.1.3 -c pytorch -c dglteam
+
+### Install dgl-ptm
+
+pip install -e dgl_ptm

--- a/environment.yaml
+++ b/environment.yaml
@@ -3,11 +3,17 @@ channels:
   - defaults
 dependencies:
   - python>=3.10
+  - pip
   - numpy
   - scipy=1.10.1
-  - pytorch::pytorch==2.0.0
-  - pytorch::torchvision==0.15.0
-  - pytorch::torchaudio==2.0.0
-  - dglteam::dgl
+  - pytorch::pytorch==2.1.0
+  - pytorch::torchvision==0.16.0
+  - pytorch::torchaudio==2.1.0
+  - dglteam::dgl==1.1.3
   - xarray
+  - ipykernel
+  - pyyaml
   - zarr
+  - pip:
+    - -e ../dgl_ptm
+

--- a/environment.yaml
+++ b/environment.yaml
@@ -15,5 +15,5 @@ dependencies:
   - pyyaml
   - zarr
   - pip:
-    - -e ../dgl_ptm
+    - -e ./dgl_ptm
 


### PR DESCRIPTION
Pinned dgl to 1.1.3 to ensure it works with the dependencies. 

Also added some instructions on readme for setting up environment. 

The new update to dgl (2.0.0) does not work well sparse libraries yet. 