### PR TITLE
Add a linter github workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   lint:
       runs-on: ubuntu-latest
+      defaults:
+        run:
+          working-directory: ./dgl_ptm
       steps:
         - uses: actions/checkout@v3
           with:
@@ -15,15 +18,16 @@ jobs:
           uses: actions/setup-python@v3
           with:
             python-version: "3.11"
-        - name: Get changed python files # for now, we only lint the changed files
+        - name: Get changed files in dgl_ptm # for now, we only lint the changed files
           id: files
           run: |
-            echo "files=$(git diff --name-only --diff-filter=d origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF -- '*.py')" >> $GITHUB_ENV
+            echo "files=$(git diff --name-only --relative --diff-filter=d origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF)" >> $GITHUB_ENV
+            echo ${{ env.files }}
         - name: Check code style against standards
           if: env.files != ''
           run: |
             python -m pip install --upgrade pip
-            python -m pip install ruff
+            python -m pip install .[dev]
             ruff check $(echo ${{ env.files }} | tr ' ' '\n')
         - name: Print message when files is empty
           if: env.files == ''

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
           working-directory: ./dgl_ptm
       steps:
         - uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
         - name: Set up Python 3.11
           uses: actions/setup-python@v3
           with:
@@ -20,17 +22,9 @@ jobs:
           run: |
             python -m pip install --upgrade pip
             python -m pip install .[dev]
-        - name: Get changed files in dgl_ptm folder  # for now, we only lint the changed files
-          id: dgl_ptm
+        - name: Get changed files folder  # for now, we only lint the changed files
+          id: files
           run: |
-            git diff --name-only ${{ github.base_ref }}...HEAD | grep '^dgl_ptm/' > $GITHUB_ENV
-            echo "dgl_ptm=$(cat $GITHUB_ENV)" >> $GITHUB_ENV
+            echo "files=$(git diff --name-only --diff-filter=d $GITHUB_BASE_REF...HEAD)" >> $GITHUB_ENV
         - name: Check source code style against standards
-          run: ruff check ${{ steps.dgl_ptm.outputs.dgl_ptm }}
-        - name: Get changed files in tests folder  # for now, we only lint the changed files
-          id: tests
-          run: |
-            git diff --name-only ${{ github.base_ref }}...HEAD | grep '^dgl_ptm/' > $GITHUB_ENV
-            echo "tests=$(cat $GITHUB_ENV)" >> $GITHUB_ENV
-        - name: Check tests code style against standards
-          run: ruff check ${{ steps.tests.outputs.tests }}
+          run: ruff check $(echo ${{ env.files }} | tr ' ' '\n')

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,6 @@ jobs:
         - name: Get changed files folder  # for now, we only lint the changed files
           id: files
           run: |
-            echo "files=$(git diff --name-only --diff-filter=d $GITHUB_BASE_REF...HEAD)" >> $GITHUB_ENV
+            echo "files=$(git diff --name-only --diff-filter=d origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF)" >> $GITHUB_ENV
         - name: Check source code style against standards
           run: ruff check $(echo ${{ env.files }} | tr ' ' '\n')

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,9 +20,15 @@ jobs:
           run: |
             python -m pip install --upgrade pip
             python -m pip install .[dev]
-        - name: Get changed files  # for now, we only lint the changed files
-          id: files
+        - name: Get changed files in dgl_ptm folder  # for now, we only lint the changed files
+          id: dgl_ptm
           run: |
-            echo "::set-output name=files::$(git diff --name-only origin/${{ github.base_ref }}...HEAD)"
-        - name: Check code style against standards
-          run: ruff check ${{ steps.files.outputs.files }}
+            echo "::set-output name=dgl_ptm::$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '^dgl_ptm/')"
+        - name: Check source code style against standards
+          run: ruff check ${{ steps.dgl_ptm.outputs.dgl_ptm }}
+        - name: Get changed files in tests folder  # for now, we only lint the changed files
+          id: tests
+          run: |
+            echo "::set-output name=tests::$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '^tests/')"
+        - name: Check tests code style against standards
+          run: ruff check ${{ steps.tests.outputs.tests }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,12 +22,14 @@ jobs:
           id: files
           run: |
             echo "files=$(git diff --name-only --relative --diff-filter=d origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF | tr '\n' ' ')" >> $GITHUB_ENV
-            echo ${{ env.files }}
-        - name: Check code style against standards
+        - name:  Install dependencies  # ruff tools are installed in the dev dependencies
           if: env.files != ''
           run: |
             python -m pip install --upgrade pip
             python -m pip install .[dev]
+        - name: Check code style against standards
+          if: env.files != ''
+          run: |
             ruff check $(echo ${{ env.files }} | tr ' ' '\n')
         - name: Print message when files is empty
           if: env.files == ''

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   lint:
       runs-on: ubuntu-latest
-      defaults:
-        run:
-          working-directory: ./dgl_ptm
       steps:
         - uses: actions/checkout@v3
           with:
@@ -18,15 +15,15 @@ jobs:
           uses: actions/setup-python@v3
           with:
             python-version: "3.11"
-        - name: Get changed files in dgl_ptm # for now, we only lint the changed files
+        - name: Get changed python files # for now, we only lint the changed files
           id: files
           run: |
-            echo "files=$(git diff --name-only --diff-filter=d origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF -- ./dgl_ptm)" >> $GITHUB_ENV
+            echo "files=$(git diff --name-only --diff-filter=d origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF -- '*.py')" >> $GITHUB_ENV
         - name: Check code style against standards
           if: env.files != ''
           run: |
             python -m pip install --upgrade pip
-            python -m pip install .[dev]
+            python -m pip install ruff
             ruff check $(echo ${{ env.files }} | tr ' ' '\n')
         - name: Print message when files is empty
           if: env.files == ''

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
         - name: Get changed python files in dgl_ptm # for now, we only lint the changed files
           id: files
           run: |
-            echo "files=$(git diff --name-only --relative --diff-filter=d -- "*.py" origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF | tr '\n' ' ')" >> $GITHUB_ENV
+            echo "files=$(git diff --name-only --relative --diff-filter=d origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF -- "*.py" | tr '\n' ' ')" >> $GITHUB_ENV
         - name:  Install dependencies  # ruff tools are installed in the dev dependencies
           if: env.files != ''
           run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,13 +18,13 @@ jobs:
           uses: actions/setup-python@v3
           with:
             python-version: "3.11"
-        - name: Install dependencies
-          run: |
-            python -m pip install --upgrade pip
-            python -m pip install .[dev]
         - name: Get changed files in dgl_ptm # for now, we only lint the changed files
           id: files
           run: |
             echo "files=$(git diff --name-only --diff-filter=d origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF -- ./dgl_ptm)" >> $GITHUB_ENV
-        - name: Check source code style against standards
-          run: ruff check $(echo ${{ env.files }} | tr ' ' '\n')
+        - name: Check code style against standards
+          if: env.files != ''
+          run: |
+            python -m pip install --upgrade pip
+            python -m pip install .[dev]
+            ruff check $(echo ${{ env.files }} | tr ' ' '\n')

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,6 @@ jobs:
           working-directory: ./dgl_ptm
       steps:
         - uses: actions/checkout@v3
-          with:
-            fetch-depth: 0
         - name: Set up Python 3.11
           uses: actions/setup-python@v3
           with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
         - name: Get changed files in dgl_ptm # for now, we only lint the changed files
           id: files
           run: |
-            echo "files=$(git diff --name-only --relative --diff-filter=d origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF)" >> $GITHUB_ENV
+            echo "files=$(git diff --name-only --relative --diff-filter=d origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF | tr '\n' ' ')" >> $GITHUB_ENV
             echo ${{ env.files }}
         - name: Check code style against standards
           if: env.files != ''

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,9 +22,9 @@ jobs:
           run: |
             python -m pip install --upgrade pip
             python -m pip install .[dev]
-        - name: Get changed files folder  # for now, we only lint the changed files
+        - name: Get changed files in dgl_ptm # for now, we only lint the changed files
           id: files
           run: |
-            echo "files=$(git diff --name-only --diff-filter=d origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF)" >> $GITHUB_ENV
+            echo "files=$(git diff --name-only --diff-filter=d origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF -- ./dgl_ptm)" >> $GITHUB_ENV
         - name: Check source code style against standards
           run: ruff check $(echo ${{ env.files }} | tr ' ' '\n')

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Linting
+
+on:
+  pull_request:  # only run on pull requests for now
+    branches: [ "master", "development" ]
+
+jobs:
+  lint:
+      runs-on: ubuntu-latest
+      defaults:
+        run:
+          working-directory: ./dgl_ptm
+      steps:
+        - uses: actions/checkout@v3
+        - name: Set up Python 3.11
+          uses: actions/setup-python@v3
+          with:
+            python-version: "3.11"
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            python -m pip install .[dev]
+        - name: Get changed files  # for now, we only lint the changed files
+          id: files
+          run: |
+            echo "::set-output name=files::$(git diff --name-only origin/${{ github.base_ref }}...HEAD)"
+        - name: Check code style against standards
+          run: ruff check ${{ steps.files.outputs.files }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
           working-directory: ./dgl_ptm
       steps:
         - uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
         - name: Set up Python 3.11
           uses: actions/setup-python@v3
           with:
@@ -23,12 +25,14 @@ jobs:
         - name: Get changed files in dgl_ptm folder  # for now, we only lint the changed files
           id: dgl_ptm
           run: |
-            echo "::set-output name=dgl_ptm::$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '^dgl_ptm/')"
+            git diff --name-only ${{ github.base_ref }}...HEAD | grep '^dgl_ptm/' > $GITHUB_ENV
+            echo "dgl_ptm=$(cat $GITHUB_ENV)" >> $GITHUB_ENV
         - name: Check source code style against standards
           run: ruff check ${{ steps.dgl_ptm.outputs.dgl_ptm }}
         - name: Get changed files in tests folder  # for now, we only lint the changed files
           id: tests
           run: |
-            echo "::set-output name=tests::$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '^tests/')"
+            git diff --name-only ${{ github.base_ref }}...HEAD | grep '^dgl_ptm/' > $GITHUB_ENV
+            echo "tests=$(cat $GITHUB_ENV)" >> $GITHUB_ENV
         - name: Check tests code style against standards
           run: ruff check ${{ steps.tests.outputs.tests }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Linting
+name: Linting with ruff  # settings are in pyproject.toml
 
 on:
   pull_request:  # only run on pull requests for now
@@ -18,10 +18,10 @@ jobs:
           uses: actions/setup-python@v3
           with:
             python-version: "3.11"
-        - name: Get changed files in dgl_ptm # for now, we only lint the changed files
+        - name: Get changed python files in dgl_ptm # for now, we only lint the changed files
           id: files
           run: |
-            echo "files=$(git diff --name-only --relative --diff-filter=d origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF | tr '\n' ' ')" >> $GITHUB_ENV
+            echo "files=$(git diff --name-only --relative --diff-filter=d "*.py" origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF | tr '\n' ' ')" >> $GITHUB_ENV
         - name:  Install dependencies  # ruff tools are installed in the dev dependencies
           if: env.files != ''
           run: |
@@ -33,4 +33,4 @@ jobs:
             ruff check $(echo ${{ env.files }} | tr ' ' '\n')
         - name: Print message when files is empty
           if: env.files == ''
-          run: echo "No files were changed."
+          run: echo "No python files were changed."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
         - name: Get changed python files in dgl_ptm # for now, we only lint the changed files
           id: files
           run: |
-            echo "files=$(git diff --name-only --relative --diff-filter=d "*.py" origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF | tr '\n' ' ')" >> $GITHUB_ENV
+            echo "files=$(git diff --name-only --relative --diff-filter=d -- "*.py" origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF | tr '\n' ' ')" >> $GITHUB_ENV
         - name:  Install dependencies  # ruff tools are installed in the dev dependencies
           if: env.files != ''
           run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,3 +28,6 @@ jobs:
             python -m pip install --upgrade pip
             python -m pip install .[dev]
             ruff check $(echo ${{ env.files }} | tr ' ' '\n')
+        - name: Print message when files is empty
+          if: env.files == ''
+          run: echo "No files were changed."

--- a/dgl_ptm/dgl_ptm/__init__.py
+++ b/dgl_ptm/dgl_ptm/__init__.py
@@ -13,5 +13,5 @@ from dgl_ptm import config
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __author__ = "Team Atlas"
-__email__ = "p.chandramouli@esciencecenter.nl"
+__email__ = "m.grootes@esciencecenter.nl"
 __version__ = "0.1.0"

--- a/dgl_ptm/dgl_ptm/__init__.py
+++ b/dgl_ptm/dgl_ptm/__init__.py
@@ -1,14 +1,17 @@
-"""Documentation about dgl_ptm"""
+"""Documentation about dgl_ptm."""
 import logging
 
-#from dgl_ptm.model import initialize_model, step
-from dgl_ptm.model.initialize_model import PovertyTrapModel
 # from dgl_ptm.agent import agent_update
 # from dgl_ptm.agentInteraction import trade_money
 # from dgl_ptm.network import global_attachment, link_deletion
 # from dgl_ptm.model import initialize_model, data_collection, step
 # from dgl_ptm.util import *
 from dgl_ptm import config
+
+#from dgl_ptm.model import initialize_model, step
+from dgl_ptm.model.initialize_model import PovertyTrapModel
+
+__all__ = ['config', 'PovertyTrapModel']
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 

--- a/dgl_ptm/pyproject.toml
+++ b/dgl_ptm/pyproject.toml
@@ -36,8 +36,6 @@ classifiers=[
     'Intended Audience :: Developers',
     'License :: OSI Approved :: Apache Software License',
     'Natural Language :: English',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
 ]
 
@@ -89,16 +87,32 @@ select = [
   "N",  # PEP8-naming
   "UP",  # pyupgrade (upgrade syntax to current syntax)
   "PLE",  # Pylint error https://github.com/charliermarsh/ruff#error-ple
+  "PLR",  # Pylint refactor (e.g. too-many-arguments)
+  "PLW",  # Pylint warning (useless-else-on-loop)
+]
+extend-select = [
+  "D401",  # First line should be in imperative mood
+  "D400",  # First line should end in a period.
+  "TID252",  # No relative imports (not pep8 compliant)
 ]
 ignore = [
-"D100", "D101", "D104", "D105", "D106", "D107", "D203", "D213"
-] # docstring style
+  "PLR2004",  # magic value used in comparsion.
+  "PLR0913",  # too many arguments
+]
 
 line-length = 88
+
 exclude = ["docs", "build"]
+
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-target-version = "py39"
+target-version = "py311"
 
 [tool.ruff.per-file-ignores]
 "tests/**" = ["D"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10

--- a/dgl_ptm/tests/test_config.py
+++ b/dgl_ptm/tests/test_config.py
@@ -4,6 +4,7 @@ import yaml
 
 from dgl_ptm.config import Config
 
+
 @pytest.fixture
 def config_parameters():
     return {
@@ -43,7 +44,7 @@ def test_to_yaml(tmp_path):
     cfg = Config()
     cfg.to_yaml(tmp_path / "config.yaml")
 
-    with open(tmp_path / "config.yaml", "r") as f:
+    with open(tmp_path / "config.yaml") as f:
         cfg_dict = yaml.safe_load(f)
     assert cfg_dict["_model_identifier"] == "test"
     assert cfg_dict["number_agents"] == 100

--- a/dgl_ptm/tests/test_config.py
+++ b/dgl_ptm/tests/test_config.py
@@ -59,7 +59,7 @@ def test_invalid_fields(config_parameters):
         _ = Config.from_dict(config_parameters)
 
 def test_invalid_values(config_parameters):
-    """Test that invalid values are not accepted."""
+    """Test invalid values."""
     config_parameters["number_agents"] = -100
     with pytest.raises(ValueError):
         _ = Config.from_dict(config_parameters)


### PR DESCRIPTION
closes #37 

Due to many linter errors in the current codes (see [here](https://github.com/SDCCA/DGL-PTM/actions/runs/10354715624/job/28660635656?pr=105)), this workflow checks only the files changed in a pull request. So, the linter issues will be fixed gradually over time.

Only changed files within `dgl_ptm` dir (the package folder) will be checked. Here I changed two files to test the workflow. 

The workflow uses [GitHub env variables](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables) because some of the common approaches are deprecated, for example, the `set-output` command is deprecated and will be disabled soon. 